### PR TITLE
Package awtempo and add config update option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+stages:
+  - test
+  - build
+
+test:
+  stage: test
+  image: python:3.10
+  script:
+    - pip install -r requirements.txt
+    - pip install -e .
+    - pytest -q
+
+build:
+  stage: build
+  image: python:3.10
+  script:
+    - pip install build
+    - python -m build
+  artifacts:
+    paths:
+      - dist/*.whl
+    expire_in: 1 week
+  only:
+    - tags

--- a/README.md
+++ b/README.md
@@ -10,16 +10,15 @@ This script converts ActivityWatch logs into Jira Tempo worklogs. It scans windo
 
 ## Installation
 
-1. Clone the repository:
+1. Install the package from GitHub:
+   ```bash
+   pip install git+https://github.com/TerrifiedBug/activitywatch-tempo.git
+   ```
+   Alternatively clone the repo and install locally:
    ```bash
    git clone https://github.com/TerrifiedBug/activitywatch-tempo.git
    cd activitywatch-tempo
-   ```
-2. Install dependencies (preferably in a virtual environment):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # Windows: venv\Scripts\activate
-   pip install -r requirements.txt
+   pip install .
    ```
 
 ## Configuration
@@ -32,11 +31,11 @@ Copy `config.json`, `mappings.json` and `static_tasks.json` and edit them to fit
 
 Generate a preview of yesterday's entries (recommended):
 ```bash
-python activitywatch-tempo.py
+aw-tempo
 ```
 Review the `tempo_preview.json` file and edit it if needed, then submit:
 ```bash
-python activitywatch-tempo.py --submit
+aw-tempo --submit
 ```
 
 ### Additional Options
@@ -46,6 +45,7 @@ python activitywatch-tempo.py --submit
 - `--direct` – process and submit without creating a preview (not recommended)
 - `--scheduler` – run a daily scheduler that processes the previous day at 08:00
 - `--config PATH` – use an alternative configuration file
+- `--update-config` – merge new default settings into your config files
 
 ## Preview File
 
@@ -54,9 +54,9 @@ The preview file contains all detected time entries with start times, durations 
 ## Example Workflow
 
 1. Ensure ActivityWatch is running.
-2. At the end of the day run `python activitywatch-tempo.py`.
+2. At the end of the day run `aw-tempo`.
 3. Open `tempo_preview.json`, tweak times or ticket keys if necessary.
-4. Submit with `python activitywatch-tempo.py --submit`.
+4. Submit with `aw-tempo --submit`.
 
 ## Logging
 

--- a/awtempo/__init__.py
+++ b/awtempo/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["main", "Config", "ActivityWatchProcessor"]
+from .cli import Config, ActivityWatchProcessor, main
+__version__ = "0.1.0"

--- a/awtempo/__main__.py
+++ b/awtempo/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/awtempo/cli.py
+++ b/awtempo/cli.py
@@ -19,6 +19,7 @@ import argparse
 import sys
 from pathlib import Path
 import time as time_module
+import shutil
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -97,6 +98,66 @@ class TimeSlot:
     @property
     def duration_seconds(self) -> int:
         return int((self.end_time - self.start_time).total_seconds())
+
+# ---------------------------------------------------------------------------
+# Configuration utilities
+# ---------------------------------------------------------------------------
+
+def merge_json_defaults(default_path: Path, user_path: Path) -> bool:
+    """Merge keys from ``default_path`` into ``user_path`` without overwriting existing values."""
+    if not default_path.exists():
+        return False
+    if not user_path.exists():
+        shutil.copy(default_path, user_path)
+        logger.info(f"Created {user_path} from defaults")
+        return True
+
+    with open(default_path, 'r') as f:
+        default_data = json.load(f)
+    with open(user_path, 'r') as f:
+        user_data = json.load(f)
+
+    changed = False
+
+    def merge(d, u):
+        nonlocal changed
+        for k, v in d.items():
+            if k not in u:
+                u[k] = v
+                changed = True
+            elif isinstance(v, dict) and isinstance(u.get(k), dict):
+                merge(v, u[k])
+
+    merge(default_data, user_data)
+
+    if changed:
+        with open(user_path, 'w') as f:
+            json.dump(user_data, f, indent=2)
+        logger.info(f"Updated {user_path} with new settings")
+
+    return changed
+
+def update_config_files(config_path: str, config: Optional['Config'] = None) -> None:
+    """Update user configuration, mappings and static task files from defaults."""
+    defaults_dir = Path(__file__).parent / 'defaults'
+    config_file = Path(config_path)
+    merge_json_defaults(defaults_dir / 'config.json', config_file)
+
+    if config is None:
+        try:
+            with open(config_file, 'r') as f:
+                data = json.load(f)
+            mappings_file = data.get('mappings_file', 'mappings.json')
+            static_file = data.get('static_tasks_file', 'static_tasks.json')
+        except Exception as e:
+            logger.error(f"Could not read config for update: {e}")
+            return
+    else:
+        mappings_file = config.mappings_file
+        static_file = config.static_tasks_file
+
+    merge_json_defaults(defaults_dir / 'mappings.json', Path(mappings_file))
+    merge_json_defaults(defaults_dir / 'static_tasks.json', Path(static_file))
 
 class ActivityWatchProcessor:
     """Processes ActivityWatch data for Jira integration"""
@@ -1293,6 +1354,12 @@ Examples:
         help='Configuration file path (default: config.json)'
     )
 
+    parser.add_argument(
+        '--update-config',
+        action='store_true',
+        help='Merge new default settings into your configuration files'
+    )
+
     return parser.parse_args()
 
 def main():
@@ -1304,6 +1371,9 @@ def main():
     except Exception as e:
         logger.error(f"Failed to initialize: {e}")
         sys.exit(1)
+
+    if args.update_config:
+        update_config_files(args.config, manager.config)
 
     # Parse date if provided
     target_date = None

--- a/awtempo/defaults/config.json
+++ b/awtempo/defaults/config.json
@@ -1,0 +1,26 @@
+{
+  "jira_url": "https://jira.domain.com",
+  "jira_pat_token": "your-jira-pat-token",
+  "worker_id": "auto",
+  "working_hours_per_day": 8,
+  "jira_ticket_pattern": "SE-\\d+",
+  "excluded_apps": ["Slack", "Personal Browser"],
+  "minimum_activity_duration_seconds": 60,
+  "time_rounding_minutes": 30,
+  "preview_file_path": "tempo_preview.json",
+  "default_processing_mode": "daily",
+  "mappings_file": "mappings.json",
+  "static_tasks_file": "static_tasks.json",
+  "log_level": "DEBUG",
+  "log_file": "activitywatch-tempo.log",
+  "lunch_enabled": false,
+  "lunch_time": "13:00",
+  "lunch_duration_minutes": 30,
+  "sequential_time_allocation": {
+    "enabled": true,
+    "work_start_time": "08:30",
+    "work_end_time": "17:00",
+    "gap_minutes": 0,
+    "static_tasks_priority": true
+  }
+}

--- a/awtempo/defaults/mappings.json
+++ b/awtempo/defaults/mappings.json
@@ -1,0 +1,89 @@
+{
+  "mappings": [
+    {
+      "name": "Zscaler TAM Meetings",
+      "pattern": "Zscaler TAM Meet",
+      "jira_key": "SE-1234",
+      "description": "Zscaler TAM vendor call",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Daily Standup Alternative",
+      "pattern": "Daily Scrum|Morning Standup",
+      "jira_key": "SE-STANDUP",
+      "description": "Daily standup meeting",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Sprint Planning",
+      "pattern": "Sprint Planning|Planning Meeting",
+      "jira_key": "SE-PLANNING",
+      "description": "Sprint planning session",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Retrospective",
+      "pattern": "Retrospective|Retro Meeting",
+      "jira_key": "SE-RETRO",
+      "description": "Sprint retrospective",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Vendor Calls",
+      "pattern": "Vendor Call|Partner Meeting|External Meeting",
+      "jira_key": "SE-VENDOR",
+      "description": "External vendor/partner call",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Training Sessions",
+      "pattern": "activitywatch-tempo.py|Training|Workshop|Learning",
+      "jira_key": "SE-TRAINING",
+      "description": "Training and development",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Code Review",
+      "pattern": "Code Review|PR Review|Pull Request",
+      "jira_key": "SE-REVIEW",
+      "description": "Code review activities",
+      "match_type": "title",
+      "enabled": true
+    },
+    {
+      "name": "Twitch App Usage",
+      "pattern": "Twitch",
+      "jira_key": "SE-twitch",
+      "description": "Twitch streaming activities",
+      "match_type": "app",
+      "enabled": true
+    },
+    {
+      "name": "Visual Studio Code",
+      "pattern": "Visual Studio Code|Code",
+      "jira_key": "SE-DEVELOPMENT",
+      "description": "Development work in VS Code",
+      "match_type": "app",
+      "enabled": false
+    },
+    {
+      "name": "Chrome Browser Work",
+      "pattern": "Google Chrome",
+      "jira_key": "SE-RESEARCH",
+      "description": "Research and browsing activities",
+      "match_type": "app",
+      "enabled": false
+    }
+  ],
+  "settings": {
+    "case_sensitive": false,
+    "priority": "first_match",
+    "fallback_to_ticket_detection": true
+  }
+}

--- a/awtempo/defaults/static_tasks.json
+++ b/awtempo/defaults/static_tasks.json
@@ -1,0 +1,48 @@
+{
+  "daily_tasks": [
+    {
+      "name": "Daily Standup",
+      "jira_key": "SE-STANDUP",
+      "time": "09:30",
+      "duration_minutes": 60,
+      "description": "Daily standup meeting",
+      "enabled": true
+    },
+    {
+      "name": "Email Review",
+      "jira_key": "SE-ADMIN",
+      "time": "08:30",
+      "duration_minutes": 15,
+      "description": "Daily email review and admin tasks",
+      "enabled": true
+    },
+    {
+      "name": "End of Day Review",
+      "jira_key": "SE-ADMIN",
+      "time": "17:00",
+      "duration_minutes": 15,
+      "description": "End of day planning and review",
+      "enabled": false
+    }
+  ],
+  "weekly_tasks": [
+    {
+      "name": "Sprint Planning",
+      "jira_key": "SE-PLANNING",
+      "day_of_week": "monday",
+      "time": "10:00",
+      "duration_minutes": 120,
+      "description": "Weekly sprint planning session",
+      "enabled": false
+    },
+    {
+      "name": "Sprint Retrospective",
+      "jira_key": "SE-RETRO",
+      "day_of_week": "friday",
+      "time": "15:00",
+      "duration_minutes": 60,
+      "description": "Weekly sprint retrospective",
+      "enabled": false
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "awtempo"
+version = "0.1.0"
+description = "ActivityWatch to Jira Tempo automation script"
+authors = [{name = "ActivityWatch Tempo"}]
+readme = "README.md"
+requires-python = ">=3.7"
+dependencies = [
+    "requests>=2.28.0",
+    "schedule>=1.2.0",
+    "python-dateutil>=2.8.0",
+]
+
+[project.scripts]
+aw-tempo = "awtempo.__main__:main"
+
+[tool.setuptools]
+packages = ["awtempo"]
+
+[tool.setuptools.package-data]
+awtempo = ["defaults/*.json"]

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -1,7 +1,6 @@
-import importlib.util
-from pathlib import Path
 import sys
 import types
+from pathlib import Path
 import pytest
 
 # Create dummy modules for external dependencies not installed in test env
@@ -9,15 +8,10 @@ for name in ["requests", "schedule", "dateutil", "dateutil.parser"]:
     if name not in sys.modules:
         sys.modules[name] = types.ModuleType(name)
 
-# Load the main script as a module since the filename contains a hyphen
-spec = importlib.util.spec_from_file_location(
-    "activitywatch_tempo",
-    Path(__file__).resolve().parents[1] / "activitywatch-tempo.py",
-)
-aw = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(aw)
-ActivityWatchProcessor = aw.ActivityWatchProcessor
-Config = aw.Config
+# Ensure the package is importable when tests run without installation
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from awtempo.cli import ActivityWatchProcessor, Config
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- convert project into `awtempo` package with entry point
- add default configuration files inside the package
- implement `--update-config` option to merge new defaults
- update documentation for pip installation and CLI usage
- add GitLab CI pipeline for testing and building
- update tests for new package layout

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_685fbf8f2b3083279ee38d315fce4bd1