### PR TITLE
Fix update-config workflow

### DIFF
--- a/awtempo/cli.py
+++ b/awtempo/cli.py
@@ -1365,6 +1365,12 @@ def main():
     """Main entry point"""
     args = parse_arguments()
 
+    # Ensure configuration files exist and optionally update them before
+    # instantiating the manager. This allows ``--update-config`` to work even
+    # when no config file has been created yet.
+    if args.update_config or not Path(args.config).exists():
+        update_config_files(args.config)
+
     try:
         manager = AutomationManager(args.config)
     except Exception as e:
@@ -1372,6 +1378,8 @@ def main():
         sys.exit(1)
 
     if args.update_config:
+        # Merge any new keys from the defaults after loading the config so that
+        # user-defined file paths are respected.
         update_config_files(args.config, manager.config)
 
     # Parse date if provided

--- a/tests/test_cli_update_config.py
+++ b/tests/test_cli_update_config.py
@@ -1,0 +1,52 @@
+import sys
+import json
+import types
+from pathlib import Path
+import importlib
+
+import pytest
+
+# Stub external dependencies used by awtempo.cli
+class DummyResponse:
+    status_code = 200
+    def json(self):
+        return {"key": "dummy"}
+
+class DummySession:
+    def __init__(self):
+        self.headers = {}
+    def get(self, url):
+        return DummyResponse()
+
+def setup_stubs(monkeypatch):
+    requests = types.ModuleType("requests")
+    requests.Session = DummySession
+    sys.modules["requests"] = requests
+    # Minimal schedule stub
+    if "schedule" not in sys.modules:
+        sys.modules["schedule"] = types.ModuleType("schedule")
+
+
+def test_update_config_creates_files(tmp_path, monkeypatch):
+    setup_stubs(monkeypatch)
+
+    # Reload module so stubs are used
+    import awtempo.cli as cli
+    importlib.reload(cli)
+
+    # Avoid heavy processing during the test
+    monkeypatch.setattr(cli.AutomationManager, "generate_preview", lambda self, mode=None, date=None: None)
+
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.json"
+
+    monkeypatch.setattr(sys, "argv", ["aw-tempo", "--update-config", "--config", str(config_path)])
+
+    cli.main()
+
+    assert config_path.exists()
+    assert (tmp_path / "mappings.json").exists()
+    assert (tmp_path / "static_tasks.json").exists()
+    with open(config_path) as f:
+        data = json.load(f)
+    assert "jira_url" in data


### PR DESCRIPTION
## Summary
- update CLI to create/merge config files before loading manager
- add regression test for `aw-tempo --update-config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fcd9426208327991b9e3c7d63253a